### PR TITLE
Bugfix for Task call ambiguities

### DIFF
--- a/AsyncClientServer.Example.Client/Client.xaml.cs
+++ b/AsyncClientServer.Example.Client/Client.xaml.cs
@@ -35,7 +35,7 @@ namespace AsyncClientServer.Example.Client
 			
 			_client = new AsyncSocketClient();
 			BindEvents();
-			Task.Run(StartClient);
+			Task.Run(() => StartClient());
 		}
 
 		private void StartClient()

--- a/AsyncClientServer/Client/AsyncSocketClient.cs
+++ b/AsyncClientServer/Client/AsyncSocketClient.cs
@@ -57,7 +57,7 @@ namespace AsyncClientServer.Client
 			TokenSource = new CancellationTokenSource();
 			Token = TokenSource.Token;
 
-			Task.Run(SendFromQueue, Token);
+			Task.Run(() => SendFromQueue(), Token);
 
 			Task.Run(() =>
 			{

--- a/AsyncClientServer/Client/AsyncSocketClient.cs
+++ b/AsyncClientServer/Client/AsyncSocketClient.cs
@@ -24,7 +24,7 @@ namespace AsyncClientServer.Client
 	/// <para>Extends <see cref="SocketClient"/>
 	/// </para>
 	/// </summary>
-	public sealed class AsyncSocketClient : SocketClient
+	public class AsyncSocketClient : SocketClient
 	{
 
 		public AsyncSocketClient(): base()

--- a/AsyncClientServer/Client/AsyncSocketSslClient.cs
+++ b/AsyncClientServer/Client/AsyncSocketSslClient.cs
@@ -83,7 +83,7 @@ namespace AsyncClientServer.Client
 			TokenSource = new CancellationTokenSource();
 			Token = TokenSource.Token;
 
-			Task.Run(SendFromQueue, Token);
+			Task.Run(() => SendFromQueue(), Token);
 
 			Task.Run(() =>
 			{
@@ -130,7 +130,7 @@ namespace AsyncClientServer.Client
 				var stream = new NetworkStream(Listener);
 				_sslStream = new SslStream(stream, false, new RemoteCertificateValidationCallback(ValidateCertificate), null);
 
-				Task.Run(SendFromQueue, Token);
+				Task.Run(() => SendFromQueue(), Token);
 
 				Task.Run(() =>
 				{

--- a/AsyncClientServer/Client/AsyncSocketSslClient.cs
+++ b/AsyncClientServer/Client/AsyncSocketSslClient.cs
@@ -17,7 +17,7 @@ using AsyncClientServer.Messaging.Metadata;
 
 namespace AsyncClientServer.Client
 {
-	public sealed class AsyncSocketSslClient : SocketClient
+	public class AsyncSocketSslClient : SocketClient
 	{
 
 		private SslStream _sslStream;

--- a/AsyncClientServer/Server/AsyncSocketListener.cs
+++ b/AsyncClientServer/Server/AsyncSocketListener.cs
@@ -20,7 +20,7 @@ namespace AsyncClientServer.Server
 	/// <para>Handles sending and receiving data to/from clients</para>
 	/// <para/>Extends <see cref="ServerListener"/>
 	/// </summary>
-	public sealed class AsyncSocketListener : ServerListener
+	public class AsyncSocketListener : ServerListener
 	{
 
 		/// <summary>

--- a/AsyncClientServer/Server/AsyncSocketSSLListener.cs
+++ b/AsyncClientServer/Server/AsyncSocketSSLListener.cs
@@ -16,7 +16,7 @@ using AsyncClientServer.Messaging.Metadata;
 
 namespace AsyncClientServer.Server
 {
-	public sealed class AsyncSocketSslListener : ServerListener
+	public class AsyncSocketSslListener : ServerListener
 	{
 		private readonly X509Certificate _serverCertificate = null;
 		private bool _acceptInvalidCertificates = true;


### PR DESCRIPTION
When compiling in VS 2017 it drops 3 same errors:
The call is ambiguous between the following methods or properties: 'Task.Run(Action, CancellationToken)' and 'Task.Run(Func<Task>, CancellationToken)'
